### PR TITLE
Spec: dateTime() should be idempotent.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2613,7 +2613,7 @@ If the second Expression is a string/integer/range literal, this is parsed as an
 </section>
 <section id="sec-dateTime" secid="10.3">
 <h3><span class="spec-secid" title="link to this section"><a href="#sec-dateTime">10.3</a></span>dateTime</h3>
-<p>The <code>dateTime</code> function takes a string, returning a datetime value.</p>
+<p>The <code>dateTime</code> function takes a string or another datatime value, returning a datetime value. This function is idempotent.</p>
 <p>global::dateTime(args, scope):</p>
 <ul>
 <li>Let <var data-name="baseNode">baseNode</var> be the first element of <var data-name="args">args</var>.</li>
@@ -2624,6 +2624,10 @@ If the second Expression is a string/integer/range literal, this is parsed as an
 <li>Return the datetime.</li>
 </ul>
 </li>
+</ul>
+</li>
+<li>If <var data-name="base">base</var> is a datetime value:<ul>
+<li>Return <var data-name="base">base</var>.</li>
 </ul>
 </li>
 <li>Return <span class="spec-keyword">null</span>.</li>

--- a/spec/Section 10 -- Functions.md
+++ b/spec/Section 10 -- Functions.md
@@ -43,7 +43,7 @@ global::countValidate(args):
 
 ## dateTime
 
-The `dateTime` function takes a string, returning a datetime value.
+The `dateTime` function takes a string or another datatime value, returning a datetime value. This function is idempotent.
 
 global::dateTime(args, scope):
 
@@ -53,6 +53,8 @@ global::dateTime(args, scope):
   * Try to parse {base} as a datetime using the [RFC 3339](https://tools.ietf.org/html/rfc3339) timestamp format.
   * If the input is a valid datetime:
       * Return the datetime.
+* If {base} is a datetime value:
+  * Return {base}.
 * Return {null}.
 
 global::dateTimeValidate(args):


### PR DESCRIPTION
Changes allow `dateTime(dateTime(x))` == `dateTime(x)`.