### PR TITLE
Specify (array) traversals

### DIFF
--- a/spec/Section 2 -- Syntax.md
+++ b/spec/Section 2 -- Syntax.md
@@ -117,11 +117,7 @@ SimpleExpression :
 CompoundExpression :
 
 * Parenthesis
-* AttributeAccess
-* ElementAccess
-* Slice
-* Filter
-* Projection
+* TraversalExpression
 * PipeFuncCall
 
 OperatorCall :
@@ -143,4 +139,3 @@ OperatorCall :
 * Slash
 * Percent
 * StarStar
-* Dereference

--- a/spec/Section 3 -- Execution.md
+++ b/spec/Section 3 -- Execution.md
@@ -113,6 +113,212 @@ The scoring function for `match` is left as an implementation detail and not cov
 
 A boosted predicate simply adds the boost value to the score if the predicate matches. For example, `boost(a > 1, 10)` would result in a score of 11 for any expression matching `a > 1`.
 
+## Traversal execution
+
+When working with JSON values you often need to access attributes in deeply nested arrays/objects.
+In JavaScript this is solved by using helper functions such as `map`, `filter` and `flatMap`.
+GROQ provides terse syntax for accomplishing the same functionality.
+
+```example
+// The following GROQ:
+*[_type == "user"]._id
+
+// is equivalent to the following JavaScript:
+data.filter(u => u._type == "user").map(u => u._id)
+```
+
+The following expressions are implemented as a *traversal*:
+
+* `foo.bar`: {AttributeAccess}.
+* `foo->`: {Dereference}.
+* `foo[0]`: {ElementAccess}.
+* `foo[0...5]`: {Slice}.
+* `foo[type == "admin"]`: {Filter}.
+* `foo[]`: {ArrayPostfix}.
+* `foo{name}`: {Projection}.
+
+When these traversals are combined (e.g. `foo.bar[0].baz[val > 2]{a, b}`) it triggers a separate traversal logic.
+
+Informally the traversal logic is based on a few principles:
+
+* Traversal semantics are always statically known.
+  The runtime value of an expression never impacts the overall interpretation of a traversal.
+* We categorize traversals into four types (plain, array, array source, array target) based on how they work on arrays.
+  `.foo.bar` is considered a *plain* traversal because it statically only deals with plain values.
+  `[_type == "user"]` is considered an *array* traversal because it works on arrays.
+* Placing a plain traversal next to an array traversals (`[_type == "user"].foo.bar`) will execute the plain traversal *for each element* of the array.
+
+Formally the semantics are specified as follows:
+
+* Each traversal has a *traverse function* which describes how it will traverse a value.
+  This function takes a value and a scope as parameters.
+* There's a set of traversal combination functions which specifies how two traversals can be combined.
+  This explains exactly how `.foo.bar` is mapped over each element of an array.
+* {TraversalPlain}, {TraversalArray}, {TraversalArraySource}, {TraversalArrayTarget} specifies the exact rules for how multiple traversals are combined together.
+* The {TraversalExpression} node is an {Expression} for the full set of traversal operators.
+  This kicks off the whole traversal semantics.
+
+### Combining traversal
+
+Multiple traversals are combined in four different ways:
+
+* *Joined*:
+  In `.user.name` we want to execute the first traversal (`.user`), and then apply the second traversal (`.name`) on the result.
+  This is specified by the {EvaluateTraversalJoin()} function.
+* *Mapped*: 
+  In `[_type == "user"].id` we want to execute the first traversal (`[_type == "user"]`), and then apply the second traversal (`.id`) for each element of the array.
+  This is specified by the {EvaluateTraversalMap()} function.
+* *Flat-mapped*: 
+  In `[_type == "user"].names[]` we want to execute the first traversal (`[_type == "user"]`), and then apply the second traversal (`.names[]`) for each element of the array, and then flatten the result.
+  This is specified by the {EvaluateTraversalFlatMap()} function.
+* *Inner mapped*: 
+  In `{name,type}[type == "admin"]` we want to execute the first traversal (`{name,type}`) for each element of the array, and then apply the second traversal (`[type == "admin"]`) on the full array.
+  This is specified by the {EvaluateTraversalInnerMap()} function.
+
+Unless otherwise specified, any two traversal are combined using the {EvaluateTraversalJoin()} function.
+
+EvaluateTraversalJoin(base, scope):
+* Let {traverse} be the traverse function of the first node.
+* Let {nextTraverse} be the traverse function of the last node.
+* Let {result} to be the result of {traverse(base, scope)}.
+* Set {result} to be the result of {nextTraverse(result, scope)}.
+* Return {result}.
+
+EvaluateTraversalMap(base, scope):
+
+* Let {traverse} be the traverse function of the first node.
+* Let {nextTraverse} be the traverse function of the last node.
+* Set {base} to be the result of {traverse(base, scope)}.
+* If {base} is not an array:
+  * Return {null}.
+* Let {result} be an empty array.
+* For each {value} in {base}:
+  * Let {elem} be the result of {nextTraverse(value, scope)}.
+  * Append {elem} to {result}.
+* Return {result}.
+
+EvaluateTraversalFlatMap(base, scope):
+
+* Let {traverse} be the traverse function of the first node.
+* Let {nextTraverse} be the traverse function of the last node.
+* Set {base} to be the result of {traverse(base, scope)}.
+* If {base} is not an array:
+  * Return {null}.
+* Let {result} be an empty array.
+* For each {value} in {base}:
+  * Let {elem} be the result of {nextTraverse(value, scope)}.
+  * If {elem} is an array:
+    * Concatenate {elem} to {result}.
+* Return {result}.
+
+EvaluateTraversalInnerMap(base, scope):
+
+* Let {traverse} be the traverse function of the first node.
+* Let {nextTraverse} be the traverse function of the last node.
+* If {base} is not an array:
+  * Return {null}.
+* Let {result} be an empty array.
+* For each {value} in {base}:
+  * Let {elem} be the result of {traverse(value, scope)}.
+  * Append {elem} to {result}.
+* Set {result} to be the result of {nextResult(base, scope)}.
+* Return {result}.
+
+
+### Plain traversal
+
+A plain traversal is a traversal which works on and returns unknown types.
+
+* `.foo.bar`
+* `.foo[0].baz`
+* `.baz->{name}`
+
+The following are _not_ considered plain traversals:
+
+* `[_type == "foo"].bar` (because it works on an array)
+* `.names[]` (because it returns an array)
+
+BasicTraversalPlain :
+
+* AttributeAccess
+* Dereference
+
+TraversalPlain : 
+
+* BasicTraversalPlain
+* BasicTraversalPlain TraversalPlain
+* BasicTraversalPlain TraversalArraySource
+* Projection
+* Projection TraversalPlain
+
+### Array traversals
+
+An array traversal is a traversal which statically is known to works on and return an array:
+
+* `[_type == "user"].id`
+* `[_type == "user"].names[]`
+* `{name,type}[type == "admin"]`
+
+The following are _not_ considered array traversals:
+
+* `[_type == "foo"].bar[0]` (because it returns an unknown type)
+* `.names[]` (because it works on a non-array)
+
+BasicTraversalArray :
+
+* Slice
+* Filter
+* ArrayPostfix
+
+TraversalArray :
+
+* BasicTraversalArray
+* BasicTraversalArray TraversalArray
+* ElementAccess TraversalArray
+* ElementAccess TraversalArrayTarget
+* BasicTraversalArray TraversalPlain "(Evaluated using EvaluateTraversalMap)"
+* BasicTraversalArray TraversalArrayTarget "(Evaluated using EvaluateTraversalFlatMap)"
+* Projection TraversalArray "(Evaluated using EvaluateTraversalInnerMap)"
+
+### Array source traversals
+
+An array source traversal is a traversal which statically is known to work on an array, but returns an unknown type:
+
+* `[0].foo.bar`
+* `[_type == "foo"].id[0]`
+* `{name,type}[0]`
+
+The following are _not_ considered array source traversals:
+
+* `[_type == "foo"].id` (because it returns an array)
+* `.foo.bar` (because it doesn't work on an array)
+
+TraversalArraySource :
+
+* ElementAccess
+* ElementAccess TraversalArraySource
+* ElementAccess TraversalPlain
+* BasicTraversalArray TraversalArraySource
+* Projection TraversalArraySource "(Evaluated using EvaluateTraversalInnerMap)"
+
+### Array target traversals
+
+An array target traversal is a traversal which statically is known to return on an array, but works on an unknown type:
+
+* `foo.bar[_type == "baz"]`
+* `{name,type}[]`
+
+The following are _not_ considered array source traversals:
+
+* `[_type == "foo"].id` (because it also works on an array)
+* `.foo.bar` (because it doesn't work on an array)
+
+TraversalArrayTarget :
+
+* BasicTraversalPlain TraversalArray
+* BasicTraversalPlain TraversalArrayTarget
+* Projection TraversalArrayTarget
+
 ## Query execution
 
 To execute a query you must first construct a query context, and then evaluate the query expression inside a root scope.

--- a/spec/Section 7 -- Compound expressions.md
+++ b/spec/Section 7 -- Compound expressions.md
@@ -19,7 +19,16 @@ EvaluateParenthesis(scope):
 
 ## Traversal expression
 
-TraversalExpression : Expression Traversal
+A traversal expressions starts a traversal.
+
+```groq
+users.foo.bar[0].sources[]->name
+```
+
+When the left-hand side is an {Everything}, {Array}, or {PipeFuncCall} this is interpreted as if there was an additional explicit {ArrayPostfix} traversal.
+E.g. `*._id` is interpreted as `*[]._id` and therefore returns an array of IDs.
+
+TraversalExpression :  Expression Traversal
 
 Traversal :
 
@@ -31,8 +40,12 @@ Traversal :
 EvaluateTraversalExpression(scope):
 
 * Let {node} be the {Expression}.
+* Let {traversalNode} be the {Traversal}.
 * Let {base} be the result of {Evaluate(node, scope)}.
-* Let {traverse} be the traverse function of the {Traversal}.
+* If {node} is one of {Everything}, {Array}, {PipeFuncCall}:
+  * Let {traverse} be the traversal function for the combination {ArrayPostfix} and {traversalNode}.
+* Otherwise:
+  * Let {traverse} be the traverse function of {traversalNode}.
 * Return {traverse(base, scope)}.
 
 

--- a/spec/Section 7 -- Compound expressions.md
+++ b/spec/Section 7 -- Compound expressions.md
@@ -17,155 +17,24 @@ EvaluateParenthesis(scope):
 * Let {result} be the result of {Evaluate(innerNode, scope)}.
 * Return {result}.
 
-## Attribute access expression
+## Traversal expression
 
-An attribute access expression returns an attribute of an object.
+TraversalExpression : Expression Traversal
 
-```
-person.name
-      ~~~~~
+Traversal :
 
-person["Full Name"]
-      ~~~~~~~~~~~~~
-```
+* TraversalPlain
+* TraversalArray
+* TraversalArraySource
+* TraversalArrayTarget
 
-AttributeAccess :
+EvaluateTraversalExpression(scope):
 
-* Expression `.` Identifier
-* Expression `[` Expression `]`
+* Let {node} be the {Expression}.
+* Let {base} be the result of {Evaluate(node, scope)}.
+* Let {traverse} be the traverse function of the {Traversal}.
+* Return {traverse(base, scope)}.
 
-Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet expressions"](#sec-Disambiguating-square-backet-expressions) for how to disambiguate between them.
-
-EvaluateAttributeAccess(scope):
-
-* Let {baseNode} be the {Expression}.
-* Let {base} be the result of {Evaluate(baseNode, scope)}.
-* If {base} is not an object, return {null}.
-* Let {name} be the string value of {String} or {Identifier}.
-* If {base} does not contain an attribute {name}, return {null}.
-* Return the value of the attribute {name} in {base}.
-
-## Element access expression
-
-An element access expression returns an element stored in an array. The array is 0-indexed and a negative index accesses the array from the end (i.e. an index of -1 returns the last element; -2 refers to the second last element).
-
-ElementAccess : Expression `[` Expression `]`
-
-Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet expressions"](#sec-Disambiguating-square-backet-expressions) for how to disambiguate between them.
-
-EvaluateElementAccess(scope):
-
-* Let {baseNode} be the first {Expression}.
-* Let {base} be the result of {Evaluate(baseNode, scope)}.
-* If {base} is not an array, return {null}.
-* Let {idxNode} be the second {Expression}.
-* Let {idx} be the result of {Evaluate(idxNode, scope)}.
-  This value is guaranteed to be an integer due to the validation.
-* If {idx} is negative, add the length of {base} to {idx}.
-* If {idx} is still negative, return {null}.
-* If {idx} is equal to or greater than the length of {base}, return {null}.
-* Return the value stored at position {idx} in {base}.
-
-ValidateElementAccess():
-
-* Let {idxNode} be the second {Expression}.
-* Let {idx} be the result of {ConstantEvaluate(idxNode)}.
-  This value is guaranteed to be a number due to square bracket disambiguation.
-* If {idx} is not an integer: Report an error.
-
-## Slice expression
-
-A slice expression returns a slice of an array.
-
-```
-people[0..10]
-      ~~~~~~~
-```
-
-Slice : Expression `[` Range `]`
-
-EvaluateSlice(scope):
-
-* Let {baseNode} be the {Expression}.
-* Let {base} be the result of {Evaluate(baseNode, scope)}.
-* If {base} is not an array, return {null}.
-* Process the left index:
-  * Let {leftNode} be the left value of the {Range}.
-  * Let {left} be the result of {Evaluate(leftNode, scope)}.
-    This value is guaranteed to be an integer due to the validation.
-  * If {left} is negative, add the length of {base} to {left}.
-  * Clamp {left} between 0 and (the length of {base} minus 1).
-* Process the right index:
-  * Let {rightNode} be the right value of the {Range}.
-  * Let {right} be the result of {Evaluate(rightNode, scope)}.
-    This value is guaranteed to be an integer due to the validation.
-  * If {right} is negative, add the length of {base} to {right}.
-  * If the {Range} is exclusive, subtract one from {right}.
-  * Clamp {right} between 0 and (the length of {base} minus 1).
-* Let {result} be an array containing the elements of {base} from position {left} up to and including position {right}.
-* Return {result}.
-
-ValidateSlice():
-
-* Let {leftNode} be the left value of the {Range}.
-* Let {leftValue} be the result of {ConstantEvaluate(leftNode)}.
-* If {leftValue} is not an integer: Report an error.
-* Let {rightNode} be the right value of the {Range}.
-* Let {rightValue} be the result of {ConstantEvaluate(rightNode)}.
-* If {rightValue} is not an integer: Report an error.
-
-## Filter expression
-
-A filter expression filters an array using another expression.
-
-```
-*[_type == "person"]
- ~~~~~~~~~~~~~~~~~~~
-```
-
-Filter : Expression `[` Expression `]`
-
-Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet expressions"](#sec-Disambiguating-square-backet-expressions) for how to disambiguate between them.
-
-EvaluateFilter(scope):
-
-* Let {baseNode} be the first {Expression}.
-* Let {base} be the result of {Evaluate(baseNode, scope)}.
-* If {base} is not an array, return {base}.
-* Let {filterNode} be the second {Expression}.
-* Let {result} be a new empty array.
-* For each element {value} in {baseValue}:
-  * Let {elementScope} be the result of {NewNestedScope(value, scope)}.
-  * Let {matched} be the result of {Evaluate(filterNode, elementScope)}.
-  * If {matched} is {true}, append {value} to {result}.
-* Return {result}.
-
-## Projection expression
-
-A projection expression iterates over an array and creates new objects for each element.
-
-```
-*[_type == "person"]{name, "isLegal": age >= 18}
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-```
-
-Projection : Expression `|`? Object
-
-EvaluateProjection(scope):
-
-* Let {baseNode} be the {Expression}.
-* Let {base} be the result of {Evaluate(baseNode, scope)}.
-* Let {objNode} be the {Object}.
-* If {base} is not an array:
-  * Let {elementScope} be the result of {NewNestedScope(base, scope)}.
-  * Let {result} be the result of {Evaluate(objNode, elementScope)}.
-* Otherwise:
-  * Let {result} be a new empty array.
-  * For each element {value} in {base}:
-    * Let {elementScope} be the result of {NewNestedScope(value, scope)}.
-    * Let {newValue} be the result of {Evaluate(objNode, elementScope)}.
-    * Append {newValue} to {result}.
-* Return {result}.
 
 ## Pipe function call expression
 
@@ -203,16 +72,196 @@ ValidatePipeFuncCall():
 * Let {validator} be the validator for the pipe function under the name {name}.
 * Execute {validator(args)}.
 
-## Disambiguating square backet expressions
+# Traversal operators
+
+## Attribute access traversal
+
+An attribute access returns an attribute of an object.
+
+```
+person.name
+      ~~~~~
+
+person["Full Name"]
+      ~~~~~~~~~~~~~
+```
+
+AttributeAccess :
+
+* `.` Identifier
+* `[` Expression `]`
+
+Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
+
+EvaluateAttributeAccess(base, scope):
+
+* If {base} is not an object, return {null}.
+* Let {name} be the string value of {String} or {Identifier}.
+* If {base} does not contain an attribute {name}, return {null}.
+* Return the value of the attribute {name} in {base}.
+
+## Element access traversal
+
+An element access returns an element stored in an array. The array is 0-indexed and a negative index accesses the array from the end (i.e. an index of -1 returns the last element; -2 refers to the second last element).
+
+ElementAccess : `[` Expression `]`
+
+Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
+
+EvaluateElementAccess(base, scope):
+
+* If {base} is not an array, return {null}.
+* Let {idxNode} be the second {Expression}.
+* Let {idx} be the result of {Evaluate(idxNode, scope)}.
+  This value is guaranteed to be an integer due to the validation.
+* If {idx} is negative, add the length of {base} to {idx}.
+* If {idx} is still negative, return {null}.
+* If {idx} is equal to or greater than the length of {base}, return {null}.
+* Return the value stored at position {idx} in {base}.
+
+ValidateElementAccess():
+
+* Let {idxNode} be the second {Expression}.
+* Let {idx} be the result of {ConstantEvaluate(idxNode)}.
+  This value is guaranteed to be a number due to square bracket disambiguation.
+* If {idx} is not an integer: Report an error.
+
+## Slice traversal
+
+A slice returns a slice of an array.
+
+```
+people[0..10]
+      ~~~~~~~
+```
+
+Slice : `[` Range `]`
+
+EvaluateSlice(base, scope):
+
+* Let {base} be the result of {Evaluate(baseNode, scope)}.
+* If {base} is not an array, return {null}.
+* Process the left index:
+  * Let {leftNode} be the left value of the {Range}.
+  * Let {left} be the result of {Evaluate(leftNode, scope)}.
+    This value is guaranteed to be an integer due to the validation.
+  * If {left} is negative, add the length of {base} to {left}.
+  * Clamp {left} between 0 and (the length of {base} minus 1).
+* Process the right index:
+  * Let {rightNode} be the right value of the {Range}.
+  * Let {right} be the result of {Evaluate(rightNode, scope)}.
+    This value is guaranteed to be an integer due to the validation.
+  * If {right} is negative, add the length of {base} to {right}.
+  * If the {Range} is exclusive, subtract one from {right}.
+  * Clamp {right} between 0 and (the length of {base} minus 1).
+* Let {result} be an array containing the elements of {base} from position {left} up to and including position {right}.
+* Return {result}.
+
+ValidateSlice():
+
+* Let {leftNode} be the left value of the {Range}.
+* Let {leftValue} be the result of {ConstantEvaluate(leftNode)}.
+* If {leftValue} is not an integer: Report an error.
+* Let {rightNode} be the right value of the {Range}.
+* Let {rightValue} be the result of {ConstantEvaluate(rightNode)}.
+* If {rightValue} is not an integer: Report an error.
+
+## Filter traversal
+
+A filter returns an array filtered another expression.
+
+```
+*[_type == "person"]
+ ~~~~~~~~~~~~~~~~~~~
+```
+
+Filter : `[` Expression `]`
+
+Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
+
+EvaluateFilter(base, scope):
+
+* If {base} is not an array, return {base}.
+* Let {filterNode} be the second {Expression}.
+* Let {result} be a new empty array.
+* For each element {value} in {baseValue}:
+  * Let {elementScope} be the result of {NewNestedScope(value, scope)}.
+  * Let {matched} be the result of {Evaluate(filterNode, elementScope)}.
+  * If {matched} is {true}, append {value} to {result}.
+* Return {result}.
+
+## Array postfix traversal
+
+An array postfix coerces the value into an array.
+
+ArrayPostfix : `[` `]`
+
+EvaluateArrayPostfix(base, scope):
+
+* If {base} is not an array, return {null}.
+* Return {base}.
+
+## Projection traversal
+
+A projection operator returns a new object.
+
+```
+*[_type == "person"]{name, "isLegal": age >= 18}
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+Projection : `|`? Object
+
+EvaluateProjection(base, scope):
+
+* Let {objNode} be the {Object}.
+* If {base} is not an object:
+  * Return {null}.
+* Let {elementScope} be the result of {NewNestedScope(base, scope)}.
+* Let {result} be the result of {Evaluate(objNode, elementScope)}.
+* Return {result}.
+
+## Dereference traversal
+
+Dereference : `->`  String?
+
+EvaluateDereference(base, scope):
+
+* If {base} is not an object:
+  * Return {null}.
+* If {base} does not have an attribute `_ref`:
+  * Return {null}.
+* Let {ref} be the value of the attribute `_ref` in {base}.
+* If {ref} is not a string:
+  * Return {null}.
+* Let {dataset} be the dataset of the query context of {scope}.
+* If {dataset} is not an array:
+  * Return {null}.
+* Let {result} be {null}.
+* For each {document} in {dataset}:
+  * If {document} is an object and has an attribute `_id`:
+      * Let {id} be the value of the attribute `_id` in {document}.
+      * If {Equal(ref, id)} is {true}:
+        * Set {result} to {document}.
+        * Stop the loop.
+* If the dereference expression contains a {String}:
+  * Let {name} be the string value of the {String}.
+  * If {result} is an object and contains an attribute {name}:
+      * Return the {value} of the attribute {name} in {result}.
+  * Otherwise:
+      * Return {null}.
+* Return {result}.
+
+## Disambiguating square backet traversal
 
 {Filter}, {ElementAccess} and {AttributeAccess} are syntactically ambiguous, and the following algorithm is used to disambiguate between them.
 
-SquareBracketExpression : Expression `[` Expression `]`
+SquareBracketTraversal : `[` Expression `]`
 
-DisambiguateSquareBracketExpression():
+DisambiguateSquareBracketTraversal():
 
-* Let {valueNode} be the last {Expression}.
+* Let {valueNode} be the {Expression}.
 * Let {value} be the result of {ConstantEvaluate(valueNode)}.
-* If {value} is a string: Interpret it as an {AttributeAccess} expression.
-* If {value} is a number: Interpret it as an {ElementAccess} expression.
-* Otherwise: Interpret it as a {Filter} expression.
+* If {value} is a string: Interpret it as an {AttributeAccess} traversal.
+* If {value} is a number: Interpret it as an {ElementAccess} traversal.
+* Otherwise: Interpret it as a {Filter} traversal.

--- a/spec/Section 8 -- Operators.md
+++ b/spec/Section 8 -- Operators.md
@@ -302,36 +302,3 @@ EvaluateStarStar(scope):
 * If both {left} and right are numbers:
   * Return the exponentiation of {left} to the power of {right}.
 * Return {null}.
-
-## Dereference operator
-
-Dereference : Expression `->`  String?
-
-EvaluateDereference(scope):
-
-* Let {valueNode} be the {Expression}.
-* Let {value} be the result of {Evaluate(valueNode, scope)}.
-* If {value} is not an object:
-  * Return {null}.
-* If {value} does not have an attribute `_ref`:
-  * Return {null}.
-* Let {ref} be the value of the attribute `_ref` in {value}.
-* If {ref} is not a string:
-  * Return {null}.
-* Let {dataset} be the dataset of the query context of {scope}.
-* If {dataset} is not an array:
-  * Return {null}.
-* Let {result} be {null}.
-* For each {document} in {dataset}:
-  * If {document} is an object and has an attribute `_id`:
-      * Let {id} be the value of the attribute `_id` in {document}.
-    * If {Equal(ref, id)} is {true}:
-          * Set {result} to {document}.
-      * Stop the loop.
-* If the dereference expression contains a {String}:
-  * Let {name} be the string value of the {String}.
-  * If {result} is an object and contains an attribute {name}:
-      * Return the {value} of the attribute {name} in {result}.
-  * Otherwise:
-      * Return {null}.
-* Return {result}.


### PR DESCRIPTION
This adds specification of how (array) traversals should work:

* A new section explaining the concept of "traversals". These are evaluated in a right-associative way.
* AttributeAccess, ElementAccess, Slice, Filter, Projection, Dereference are no longer standalone expressions, but rather part of a traversal.
* Adds all of the rules for how traversals are combined and when join/mapping/flat-mapping is happening.