### PR TITLE
Specify now() function

### DIFF
--- a/spec/Section 10 -- Functions.md
+++ b/spec/Section 10 -- Functions.md
@@ -100,7 +100,10 @@ global::lengthValidate(args):
 
 ### global::now()
 
-The now function returns the current timestamp as a string.
+The now function returns the current point in time as a string.
+
+Note: This function returns a string due to backwards compatibility.
+It's recommended to use `dateTime::now()` instead which returns a proper datetime.
 
 global::now(args, scope):
 
@@ -296,3 +299,21 @@ global::upperValidate(args):
   * Report an error.
 
 In addition to the functions mentioned above, constructors for [extensions](#sec-Extensions) are global as well.
+
+## DateTime namespace
+
+The `dateTime` namespace contains functions to work with datetimes.
+
+### dateTime::now()
+
+The now function in the `dateTime` namespace returns the current point in time as a datetime.
+
+dateTime::now(args, scope):
+
+* Let {result} be a datetime representing the current point in time.
+* Return {result}.
+
+dateTime::nowValidate(args):
+
+* If the length of {args} is not 0:
+  * Report an error.

--- a/spec/Section 10 -- Functions.md
+++ b/spec/Section 10 -- Functions.md
@@ -98,6 +98,21 @@ global::lengthValidate(args):
 * If the length of {args} is not 1:
   * Report an error.
 
+### global::now()
+
+The now function returns the current timestamp as a string.
+
+global::now(args, scope):
+
+* Let {ts} be a datetime representing the current point in time.
+* Let {result} be a RFC3339 string formatting of {ts}.
+* Return {result}.
+
+global::nowValidate(args):
+
+* If the length of {args} is not 0:
+  * Report an error.
+
 ### global::references()
 
 The references function implicitly takes this value of the current scope and recursively checks whether it contains any references to the given document ID.

--- a/spec/Section 10 -- Functions.md
+++ b/spec/Section 10 -- Functions.md
@@ -108,7 +108,7 @@ It's recommended to use `dateTime::now()` instead which returns a proper datetim
 global::now(args, scope):
 
 * Let {ts} be a datetime representing the current point in time.
-* Let {result} be a RFC3339 string formatting of {ts}.
+* Let {result} be a [RFC 3339](https://tools.ietf.org/html/rfc3339) string formatting of {ts}.
 * Return {result}.
 
 global::nowValidate(args):

--- a/spec/Section 10 -- Functions.md
+++ b/spec/Section 10 -- Functions.md
@@ -300,7 +300,7 @@ global::upperValidate(args):
 
 In addition to the functions mentioned above, constructors for [extensions](#sec-Extensions) are global as well.
 
-## DateTime namespace
+## Date/time namespace
 
 The `dateTime` namespace contains functions to work with datetimes.
 


### PR DESCRIPTION
This adds specification for the `now()` function.

I also introduced a new function `dateTime::now()` which returns a "real" datetime object. Over time we can try to deprecate the global `now()` function (because it returns a string).