### PR TITLE
build: change tagging/revision system

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - main
     tags:
-    - v*
+    - GROQ-*
 
 jobs:
   scheduled:

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -69,7 +69,7 @@ async function main() {
   let isFirst = true
 
   for (const line of lines) {
-    const [version, date] = line.split(' ')
+    const [date, version] = line.split(' ')
     versions.push({
       slug: version,
       name: version,

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -15,7 +15,7 @@ echo "Publishing to: /draft"
 rm -rf "$PUBLISH_DIR/draft"
 cp -R out/ "$PUBLISH_DIR/draft"
 
-CURRENT_VERSION=$(git tag --points-at HEAD | grep 'v\d.*')
+CURRENT_VERSION=$(git tag --points-at HEAD | grep 'GROQ-\d.*')
 
 # If this is a tagged commit, publish to a permalink and index.
 if [ -n "$CURRENT_VERSION" ]; then
@@ -25,7 +25,7 @@ fi
 
 # Update index
 echo "Updating index"
-git tag -l --format='%(refname:lstrip=2) %(creatordate:unix)' | sort -r |
+git tag -l --format='%(creatordate:unix) %(refname:lstrip=2)' | sort -r |
   node scripts/generate-index.js > "$PUBLISH_DIR/index.html"
 
 echo "Done"


### PR DESCRIPTION
We can now tag versions as `GROQ-{MAJOR}.revision{REV}` and it will correctly show up on the web page.