### PR TITLE
Fix various typos and formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# This is a bit annoying. There's _one_ code block where we want to
+# avoid auto-formatting JSON, but spec-md doesn't support inline
+# <-- prettier-ignore -->. Luckily this file is quite small
+# so let's just disable Prettier for now.
+spec/01-overview.md

--- a/spec/01-overview.md
+++ b/spec/01-overview.md
@@ -24,7 +24,6 @@ The following query:
 
 Will result in the following JSON document:
 
-<!-- prettier-ignore -->
 ```json
 [
   { "name": "Drax"},

--- a/spec/01-overview.md
+++ b/spec/01-overview.md
@@ -18,7 +18,7 @@ Given these JSON documents:
 
 The following query:
 
-```groq
+```example
 *[id > 2]{name}
 ```
 

--- a/spec/02-syntax.md
+++ b/spec/02-syntax.md
@@ -8,12 +8,12 @@ SourceCharacter : "any Unicode character"
 
 GROQ's syntax is a superset of JSON, so any valid JSON value is a valid GROQ expression (that simply returns the given value). Below are a few examples of JSON values:
 
-```
+```json
 "Hi! 👋"
 ```
 
-```javascript
-;['An', 'array', 'of', 'strings']
+```json
+["An", "array", "of", "strings"]
 ```
 
 ```json
@@ -52,7 +52,7 @@ CommentChar : SourceCharacter but not "Newline U+000A"
 
 Comments serve as query documentation, and are ignored by the parser. They start with `//` and run to the end of the line:
 
-```
+```example
 {
   // Comments can be on a separate line
   "key": "value" // Or at the end of a line
@@ -61,7 +61,7 @@ Comments serve as query documentation, and are ignored by the parser. They start
 
 Comments cannot start inside a string literal.
 
-```
+```example
 {
   "key // This isn't a comment": "value"
 }

--- a/spec/03-execution.md
+++ b/spec/03-execution.md
@@ -6,7 +6,7 @@ Note: The following sub-section is a non-normative overview of the execution mod
 
 A GROQ query is executed inside a query context, which contains the dataset and parameters, and returns a result. Typically the result is serialized to JSON. During the execution of a query different parts of the query are evaluated in different scopes. Each scope has a *this *value and can be nested. Simple attributes like `name` always refers to an attribute on the *this *value.
 
-```groq
+```example
 *[_type == "person"]{name, friends[country == "NO"]}
 ```
 
@@ -17,7 +17,7 @@ In the preceding example we have several scopes:
 
 The parent expression (`^`) let's you refer to parent scopes, and this enables what is typically solved with joins in many databases.
 
-```groq
+```example
 *[_type == "person"]{
   id,
   name,
@@ -76,7 +76,7 @@ NewRootScope(context):
 
 ## Expression validation
 
-An expression can be validated. This will only check that it's on a valid form, and will not execute anything. If an expression type does not have an explicitly defined validator in this specifiction, it has an implicit validator which runs {Validate} on all its child expressions.
+An expression can be validated. This will only check that it's on a valid form, and will not execute anything. If an expression type does not have an explicitly defined validator in this specification, it has an implicit validator which runs {Validate} on all its child expressions.
 
 Validate(expr):
 
@@ -108,7 +108,7 @@ ConstantEvaluate(expr):
 
 When evaluating {score}, a predicate returning `true` should have its score computed as 1.0, and all other values should receive a score of 0.0. All results involved in scoring start with a score of 1.0. The scores are evaluated once per result, and then added together. For example:
 
-```groq
+```example
 * | score(a > 1)
 ```
 

--- a/spec/04-data-types.md
+++ b/spec/04-data-types.md
@@ -44,7 +44,7 @@ A string stores an UTF-8 encoded list of characters.
 The syntax of a string literal is a subset of JSON with the following extensions:
 
 - Any control characters (including newlines) are allowed to appear inside a string.
-- Extended support for refering to Unicode characters above 16-bit: `"\u{1F600}"`.
+- Extended support for referring to Unicode characters above 16-bit: `"\u{1F600}"`.
 
 String :
 
@@ -91,7 +91,7 @@ It's a syntactical error when a Unicode escape sequence represents an invalid Un
 
 ## Array
 
-An ordered collection of values, e.g. `[1, 2, 3]`. Can contain any combination of other types, including other arrays and mixed types. An element inside an array literal can be preceeded by `...` which causes it to be flattened into the array.
+An ordered collection of values, e.g. `[1, 2, 3]`. Can contain any combination of other types, including other arrays and mixed types. An element inside an array literal can be preceded by `...` which causes it to be flattened into the array.
 
 Array : [ ArrayElements? `,`? ]
 
@@ -153,7 +153,7 @@ EvaluateObject(scope):
 - Let {result} be a new empty object.
 - For each {ObjectAttribute}:
   - If the {ObjectAttribute} contains `...`:
-    - If the {ObjectAttribute} constains an {Expression}:
+    - If the {ObjectAttribute} contains an {Expression}:
       - Let {baseNode} be the {Expression}.
     - Let {base} be the result of {Evaluate(baseNode, scope)}.
     - Otherwise:
@@ -218,7 +218,7 @@ An interval containing all values that are ordered between the start and end val
 
 Ranges can have endpoints of any comparable data type, but both endpoints must be of the same type (except integers and floats which can be used interchangeably). Ranges with incompatible or invalid endpoints types will yield `null`.
 
-Ranges are mainly used internally, e.g. with the `in` operator and array slice access operator. The endpoints may have context-dependant semantics, e.g. in array slices the range `[2..-1]` will cover the range from the third array element to the last element, while the same range is considered empty when used with `in`. For more details, see the documentation for the relevant operators.
+Ranges are mainly used internally, e.g. with the `in` operator and array slice access operator. The endpoints may have context-dependent semantics, e.g. in array slices the range `[2..-1]` will cover the range from the third array element to the last element, while the same range is considered empty when used with `in`. For more details, see the documentation for the relevant operators.
 
 In serialized JSON, ranges are represented as a string on the form `start..end` (for inclusive ranges) and `start...end` (for exclusive ranges) where `start` and `end` are the serialized JSON for the start and the end expression.
 
@@ -236,7 +236,7 @@ EvaluateRange(scope):
 - Let {startNode} be the first {Expression}.
 - Let {endNode} be the second {Expression}.
 - Let {start} be the result of {Evaluate(startNode, scope)}.
-- Let {end} be the result of {Evalaute(endNode, scope)}.
+- Let {end} be the result of {Evaluate(endNode, scope)}.
 - If {PartialCompare(start, end)} is {null}:
   - Return {null}.
 - Let {result} be a new range.

--- a/spec/04-data-types.md
+++ b/spec/04-data-types.md
@@ -121,7 +121,7 @@ An unordered collection of key/value pairs (referred to as attributes) with uniq
 
 The values of an object literal can use the full power of expressions:
 
-```
+```example
 *[_type == "rect"]{"area": width * height}
 ```
 
@@ -129,7 +129,7 @@ Note: A {Projection} expression is just an expression with an object literal to 
 
 Object literal supports syntactical sugar when the attribute name and value is equivalent:
 
-```
+```example
 // These two are equivalent
 *[_type == "person"]{name}
 *[_type == "person"]{"name": name}

--- a/spec/06-simple-expressions.md
+++ b/spec/06-simple-expressions.md
@@ -4,7 +4,7 @@
 
 A this expression returns the this value of the current scope.
 
-```groq
+```example
 *[_id == "doc"][0].numbers[@ >= 10]
                            ~
 ```
@@ -19,7 +19,7 @@ EvaluateThis(scope):
 
 A *this attribute expression *returns an attribute from the this value of the current scope.
 
-```
+```example
 *[_id == "document"][name == "Michael Bluth"]
   ~~~                ~~~~
 ```
@@ -38,7 +38,7 @@ EvaluateThisAttribute(scope):
 
 An everything expression returns the full dataset.
 
-```
+```example
 *[_type == "person"]
 ~
 ```
@@ -54,7 +54,7 @@ EvaluateEverything(scope):
 
 A parent expression returns a this value for an upper scope.
 
-```
+```example
 // Find all people who have a cool friend
 *[_type == "person" && *[_id == ^.friend._ref][0].isCool]
                                 ~
@@ -79,7 +79,7 @@ EvaluateParent(scope):
 
 GROQ comes with a set of built-in functions which provides additional features. See the ["Functions"](#sec-Functions) for available functions and their namespaces.
 
-```
+```example
 *{"score": round(score, 2)}
            ~~~~~~~~~~~~~~~
 

--- a/spec/07-compound-expressions.md
+++ b/spec/07-compound-expressions.md
@@ -4,7 +4,7 @@
 
 A parenthesis expression allows you to add parenthesis around another expression to control precedence of operators.
 
-```groq
+```example
 (1 + 2) * 3
 ~~~~~~~
 ```
@@ -21,7 +21,7 @@ EvaluateParenthesis(scope):
 
 A traversal expressions starts a traversal.
 
-```groq
+```example
 users.foo.bar[0].sources[]->name
 ```
 
@@ -52,7 +52,7 @@ EvaluateTraversalExpression(scope):
 
 GROQ comes with a set of built-in pipe functions which provides additional features. Pipe functions always accepts an array on the left-hand side and returns another array, and the syntax is optimized for being able to chain it together with other compund expressions. See the ["Pipe functions"](#sec-Pipe-functions) for available functions.
 
-```
+```example
 *[_type == "person"] | order(name) | {age}
                      ~~~~~~~~~~~~~
 ```

--- a/spec/07-compound-expressions.md
+++ b/spec/07-compound-expressions.md
@@ -50,7 +50,7 @@ EvaluateTraversalExpression(scope):
 
 ## Pipe function call expression
 
-GROQ comes with a set of built-in pipe functions which provides additional features. Pipe functions always accepts an array on the left-hand side and returns another array, and the syntax is optimized for being able to chain it together with other compund expressions. See the ["Pipe functions"](#sec-Pipe-functions) for available functions.
+GROQ comes with a set of built-in pipe functions which provides additional features. Pipe functions always accepts an array on the left-hand side and returns another array, and the syntax is optimized for being able to chain it together with other compound expressions. See the ["Pipe functions"](#sec-Pipe-functions) for available functions.
 
 ```example
 *[_type == "person"] | order(name) | {age}

--- a/spec/08-traversal-operators.md
+++ b/spec/08-traversal-operators.md
@@ -4,7 +4,7 @@
 
 An attribute access returns an attribute of an object.
 
-```
+```example
 person.name
       ~~~~~
 
@@ -56,7 +56,7 @@ ValidateElementAccess():
 
 A slice returns a slice of an array.
 
-```
+```example
 people[0..10]
       ~~~~~~~
 ```
@@ -96,7 +96,7 @@ ValidateSlice():
 
 A filter returns an array filtered another expression.
 
-```
+```example
 *[_type == "person"]
  ~~~~~~~~~~~~~~~~~~~
 ```
@@ -131,7 +131,7 @@ EvaluateArrayPostfix(base, scope):
 
 A projection operator returns a new object.
 
-```
+```example
 *[_type == "person"]{name, "isLegal": age >= 18}
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```

--- a/spec/08-traversal-operators.md
+++ b/spec/08-traversal-operators.md
@@ -17,7 +17,7 @@ AttributeAccess :
 - `.` Identifier
 - `[` Expression `]`
 
-Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
+Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square bracket traversal"](#sec-Disambiguating-square-bracket-traversal) for how to disambiguate between them.
 
 EvaluateAttributeAccess(base, scope):
 
@@ -32,7 +32,7 @@ An element access returns an element stored in an array. The array is 0-indexed 
 
 ElementAccess : `[` Expression `]`
 
-Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
+Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square bracket traversal"](#sec-Disambiguating-square-bracket-traversal) for how to disambiguate between them.
 
 EvaluateElementAccess(base, scope):
 
@@ -103,7 +103,7 @@ A filter returns an array filtered another expression.
 
 Filter : `[` Expression `]`
 
-Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square backet traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
+Note: {Filter}, {ElementAccess}, {AttributeAccess} are syntactically ambiguous. See ["Disambiguating square bracket traversal"](#sec-Disambiguating-square-backet-traversal) for how to disambiguate between them.
 
 EvaluateFilter(base, scope):
 
@@ -178,7 +178,7 @@ EvaluateDereference(base, scope):
     - Return {null}.
 - Return {result}.
 
-## Disambiguating square backet traversal
+## Disambiguating square bracket traversal
 
 {Filter}, {ElementAccess} and {AttributeAccess} are syntactically ambiguous, and the following algorithm is used to disambiguate between them.
 

--- a/spec/10-precedence-associativity.md
+++ b/spec/10-precedence-associativity.md
@@ -6,7 +6,7 @@ From highest to lowest:
 
 - Level 11: [Compound expressions](#sec-Compound-expressions).
 - Level 10, prefix: `+`, `!`.
-- Level 9, right-assoative: [](#sec-Binary-double-star-operator) `**`.
+- Level 9, right-associative: [](#sec-Binary-double-star-operator) `**`.
 - Level 8, prefix: `-`.
 - Level 7, left-associative: Multiplicatives (`*`, `/`, `%`).
 - Level 6, left-associative: Additives (`+`, `-`),

--- a/spec/11-functions.md
+++ b/spec/11-functions.md
@@ -12,11 +12,11 @@ Functions are namespaced which allows to group functions by logical scope. A fun
 
 The after function, in delta mode, returns the attributes after the change.
 
-global::after(args, scope):
+global_after(args, scope):
 
 - Return the after object of the query context of {scope}.
 
-global::afterValidate(args, scope):
+global_after_validate(args, scope):
 
 - If the length of {args} is not 0:
   - Report an error.
@@ -27,11 +27,11 @@ global::afterValidate(args, scope):
 
 The before function, in delta mode, returns the attributes before the change.
 
-global::before(args, scope):
+global_before(args, scope):
 
 - Return the before object of the query context of {scope}.
 
-global::beforeValidate(args, scope):
+global_before_validate(args, scope):
 
 - If the length of {args} is not 0:
   - Report an error.
@@ -42,7 +42,7 @@ global::beforeValidate(args, scope):
 
 The coalesce function returns the first value of the arguments which is not {null}.
 
-global::coalesce(args, scope):
+global_coalesce(args, scope):
 
 - For each {arg} in {args}:
   - Let {value} be the result of {Evaluate(arg, scope)}.
@@ -54,7 +54,7 @@ global::coalesce(args, scope):
 
 The count function returns the length of an array.
 
-global::count(args, scope):
+global_count(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -63,7 +63,7 @@ global::count(args, scope):
 - Otherwise:
   - Return {null}.
 
-global::countValidate(args):
+global_count_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -72,7 +72,7 @@ global::countValidate(args):
 
 The `dateTime` function takes a string or another datatime value, returning a datetime value. This function is idempotent.
 
-global::dateTime(args, scope):
+global_dateTime(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -84,7 +84,7 @@ global::dateTime(args, scope):
   - Return {base}.
 - Return {null}.
 
-global::dateTimeValidate(args):
+global_dateTime_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -93,7 +93,7 @@ global::dateTimeValidate(args):
 
 The defined function checks if the argument is not {null}.
 
-global::defined(args, scope):
+global_defined(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -102,7 +102,7 @@ global::defined(args, scope):
 - Otherwise:
   - Return {true}.
 
-global::definedValidate(args):
+global_defined_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -111,7 +111,7 @@ global::definedValidate(args):
 
 The length function returns the length of a string or an array.
 
-global::length(args, scope):
+global_length(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -121,7 +121,7 @@ global::length(args, scope):
   - Return the length of {base}.
 - Return {null}.
 
-global::lengthValidate(args):
+global_length_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -133,13 +133,13 @@ The now function returns the current point in time as a string.
 Note: This function returns a string due to backwards compatibility.
 It's recommended to use `dateTime::now()` instead which returns a proper datetime.
 
-global::now(args, scope):
+global_now(args, scope):
 
 - Let {ts} be a datetime representing the current point in time.
 - Let {result} be a [RFC 3339](https://tools.ietf.org/html/rfc3339) string formatting of {ts}.
 - Return {result}.
 
-global::nowValidate(args):
+global_now_validate(args):
 
 - If the length of {args} is not 0:
   - Report an error.
@@ -148,7 +148,7 @@ global::nowValidate(args):
 
 The operation function returns the current operation ({"create"}, {"update"}, {"delete"}) of a change in delta mode.
 
-global::operation(args, scope):
+global_operation(args, scope):
 
 - Let {before} and {after} be the before/after objects of the query context to {scope}.
 - If {before} is {null}:
@@ -157,7 +157,7 @@ global::operation(args, scope):
   - Return {"delete"}.
 - Return {"update"}.
 
-global::operationValidate(args):
+global_operation_validate(args):
 
 - If the length of {args} is not 0:
   - Report an error.
@@ -166,7 +166,7 @@ global::operationValidate(args):
 
 The references function implicitly takes this value of the current scope and recursively checks whether it contains any references to the given document ID.
 
-global::references(args, scope):
+global_references(args, scope):
 
 - Let {pathSet} be an empty array.
 - For each {arg} of {args}:
@@ -180,7 +180,7 @@ global::references(args, scope):
 - Let {base} be the this value of {scope}.
 - Return the result of {HasReferenceTo(base, pathSet)}.
 
-global::HasReferenceTo(base, pathSet):
+HasReferenceTo(base, pathSet):
 
 - If {base} is an array:
   - For each {value} in {base}:
@@ -201,7 +201,7 @@ global::HasReferenceTo(base, pathSet):
       - Return {true}.
 - Return {false}.
 
-global::referencesValidate(args):
+global_references_validate(args):
 
 - If the length of {args} is 0:
   - Report an error.
@@ -210,7 +210,7 @@ global::referencesValidate(args):
 
 The round function accepts a number and rounds it to a certain precision.
 
-global::round(args, scope):
+global_round(args, scope):
 
 - Let {numNode} be the first element of {args}.
 - Let {num} be the result of {Evaluate(numNode, scope)}.
@@ -225,7 +225,7 @@ global::round(args, scope):
   - Let {prec} be 0.
 - Return {num} rounded to {prec} number of digits after the decimal point.
 
-global::roundValidate(args):
+global_round_validate(args):
 
 - If the length of {args} is less than 1 or greater than 2:
   - Report an error.
@@ -234,7 +234,7 @@ global::roundValidate(args):
 
 The select function chooses takes a variable number of arguments that are either pairs or any other type and iterates over them. When encountering a pair whose left-hand value evaluates to {true}, the right-hand value is returned immediately. When encountering a non-pair argument, that argument is returned immediately. Falls back to returning {null}.
 
-global::select(args, scope):
+global_select(args, scope):
 
 - For each {arg} in {args}:
   - If {arg} is a {Pair}:
@@ -246,7 +246,7 @@ global::select(args, scope):
   - Otherwise:
     - Return the result of {Evaluate(arg, scope)}.
 
-global::selectValidate(args):
+global_select_validate(args):
 
 - Let {seenDefault} be {false}.
 - For each {arg} in {args}:
@@ -259,7 +259,7 @@ global::selectValidate(args):
 
 The string function returns the string representation of scalar values or {null} for any other values.
 
-global::string(args, scope):
+global_string(args, scope):
 
 - Let {node} be the first element of {args}.
 - Let {val} be the result of {Evaluate(node, scope)}.
@@ -276,7 +276,7 @@ global::string(args, scope):
 - Otherwise:
   - Return {null}.
 
-global::stringValidate(args):
+global_string_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -307,7 +307,7 @@ boost(args, scope):
   - Return {null}.
 - Return {result}.
 
-boostValidate(args):
+boost_validate(args):
 
 - If the length of {args} is not 2:
   - Report an error.
@@ -316,14 +316,14 @@ boostValidate(args):
 
 The lower function returns lowercased string.
 
-global::lower(args, scope):
+global_lower(args, scope):
 
 - Let {value} be the result of {Evaluate(arg, scope)}.
 - If {value} is not {null}:
   - Return lowercase form of {value}.
 - Return {null}.
 
-global::lowerValidate(args):
+global_lower_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -332,14 +332,14 @@ global::lowerValidate(args):
 
 The upper function returns uppercased string.
 
-global::upper(args, scope):
+global_upper(args, scope):
 
 - Let {value} be the result of {Evaluate(arg, scope)}.
 - If {value} is not {null}:
   - Return uppercase form of {value}.
 - Return {null}.
 
-global::upperValidate(args):
+global_upper_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -354,12 +354,12 @@ The `dateTime` namespace contains functions to work with datetimes.
 
 The now function in the `dateTime` namespace returns the current point in time as a datetime.
 
-dateTime::now(args, scope):
+dateTime_now(args, scope):
 
 - Let {result} be a datetime representing the current point in time.
 - Return {result}.
 
-dateTime::nowValidate(args):
+dateTime_now_validate(args):
 
 - If the length of {args} is not 0:
   - Report an error.
@@ -372,14 +372,14 @@ The `delta` namespace contains functions which are valid in delta mode.
 
 `delta::changedAny` is a variant of `diff::changedAny` which works on the before/after objects.
 
-delta::changedAny(args, scope):
+delta_changedAny(args, scope):
 
 - Let {before} and {after} be the before/after objects of the query context to {scope}.
 - Let {selector} by the first element of {args}.
 - Let {result} be the result of {diff_changedAny(before, after, selector)}.
 - Return {result}.
 
-delta::changedAnyValidate(args, scope):
+delta_changedAny_validate(args, scope):
 
 - If the mode of the query context of {scope} is not "delta":
   - Report an error.
@@ -390,14 +390,14 @@ delta::changedAnyValidate(args, scope):
 
 `delta::changedOnly` is a variant of `diff::changedOnly` which works on the before/after objects.
 
-delta::changedOnly(args, scope):
+delta_changedOnly(args, scope):
 
 - Let {before} and {after} be the before/after objects of the query context to {scope}.
 - Let {selector} by the first element of {args}.
 - Let {result} be the result of {diff_changedOnly(before, after, selector)}.
 - Return {result}.
 
-delta::changedOnlyValidate(args, scope):
+delta_changedOnly_validate(args, scope):
 
 - If the mode of the query context of {scope} is not "delta":
   - Report an error.

--- a/spec/11-functions.md
+++ b/spec/11-functions.md
@@ -2,7 +2,7 @@
 
 Functions provide additional functionality to GROQ queries. They are invoked through a [Function call expression](#sec-Function-call-expression). Note that function arguments are not evaluated eagerly, and it's up to the function to decide which scope the arguments are evaluated it. As such, all functions below take an array of nodes.
 
-An implementation may provide additional functions, but should be aware that this can cause problems when interopting with future versions of GROQ.
+An implementation may provide additional functions, but should be aware that this can cause problems when interoperating with future versions of GROQ.
 
 Functions are namespaced which allows to group functions by logical scope. A function may be associated with multiple namespaces and behave differently. When a function is called without a namespace, it is by default associated with a "**global**" namespace.
 

--- a/spec/11-functions.md
+++ b/spec/11-functions.md
@@ -285,7 +285,7 @@ global::stringValidate(args):
 
 The `boost` function accepts an expression and a boost value, and increases or decreases the score computed by `score()` (see ["Pipe functions"](#sec-Pipe-functions)) accordingly. `boost` can only be used within the argument list to `score()`.
 
-```groq
+```example
 * | score(boost(title matches "milk", 5.0), body matches "milk")
 ```
 

--- a/spec/12-pipe-functions.md
+++ b/spec/12-pipe-functions.md
@@ -1,6 +1,6 @@
 # Pipe functions
 
-Pipe functions provide additional functionalty to GROQ queries. They are invoked through a [Pipe function call expression](#sec-Pipe-function-call-expression). They differ from regular functions in that they always accept an array as input and returns another array (or {null}). As such, the syntax is optimized for chaining (the array it works on comes on the left-hand side instead of being an argument):
+Pipe functions provide additional functionality to GROQ queries. They are invoked through a [Pipe function call expression](#sec-Pipe-function-call-expression). They differ from regular functions in that they always accept an array as input and returns another array (or {null}). As such, the syntax is optimized for chaining (the array it works on comes on the left-hand side instead of being an argument):
 
 ```example
 *[_type == "person"] | order(name) | {age}

--- a/spec/12-pipe-functions.md
+++ b/spec/12-pipe-functions.md
@@ -2,13 +2,13 @@
 
 Pipe functions provide additional functionalty to GROQ queries. They are invoked through a [Pipe function call expression](#sec-Pipe-function-call-expression). They differ from regular functions in that they always accept an array as input and returns another array (or {null}). As such, the syntax is optimized for chaining (the array it works on comes on the left-hand side instead of being an argument):
 
-```
+```example
 *[_type == "person"] | order(name) | {age}
 ```
 
 Note that function arguments are not evaluated eagerly, and it's up to the function to decide which scope the arguments are evaluated in. All definitions below take an array of nodes.
 
-An implementation may provide additional pipe functions, but should be aware that this can cause problems when interopting with future versions of GROQ.
+An implementation may provide additional pipe functions, but should be aware that this can cause problems when interoperating with future versions of GROQ.
 
 ## global::order()
 
@@ -44,13 +44,13 @@ orderValidate(args):
 
 The `score` function assigns a score to an array of results, based on one or more scoring expressions. The `score` function may only be used as a pipe function.
 
-```groq
+```example
 *[_type == "listing"] | score(body match "jacuzzi")
 ```
 
 In this query, anything where `body match "jacuzzi"` returns true will be scored higher than other results. Multiple expressions can be used:
 
-```groq
+```example
 *[_type == "listing"] | score(body match "jacuzzi", bedrooms > 2, available && !inContract)
 ```
 

--- a/spec/12-pipe-functions.md
+++ b/spec/12-pipe-functions.md
@@ -35,7 +35,7 @@ order(base, args, scope):
   - Return {Equal}.
 - Return a sorted array using {cmp} as the comparator function.
 
-orderValidate(args):
+order_validate(args):
 
 - If the length of {args} is 0:
   - Report an error.
@@ -90,7 +90,7 @@ EvaluateScore(expr, scope):
 - Let {evaluator} be the score evaluator of {expr}.
 - Return the result of {evaluator(scope)}.
 
-scoreValidate(args):
+score_validate(args):
 
 - If the length of {args} is 0:
   - Report an error.

--- a/spec/13-vendor-functions.md
+++ b/spec/13-vendor-functions.md
@@ -1,6 +1,6 @@
 # Vendor functions
 
-An implementation is free to introduce additional functions than what is presented in this specification, but this is problematic if a function with the same name is introduced in a future version. The following section defines optional _vendor functions_ which are guaranteed to never be a regular function in a future specfication. There's also a short description of each vendor function so different implementations can attempt to be compatible with each other. The description is intentially brief and it's up to the vendor to define it completely.
+An implementation is free to introduce additional functions than what is presented in this specification, but this is problematic if a function with the same name is introduced in a future version. The following section defines optional _vendor functions_ which are guaranteed to never be a regular function in a future specification. There's also a short description of each vendor function so different implementations can attempt to be compatible with each other. The description is intentionally brief and it's up to the vendor to define it completely.
 
 ## global::identity()
 

--- a/spec/14-extensions.md
+++ b/spec/14-extensions.md
@@ -197,7 +197,7 @@ diff_changedAny(args, scope):
 - Otherwise:
   - Return {false}.
 
-diff_changedAny(args):
+diff_changedAny_validate(args):
 
 - If the length of {args} is not 3:
   - Report an error
@@ -222,7 +222,7 @@ diff_changedOnly(args, scope):
 - Otherwise:
   - Return {false}.
 
-diff_changedOnly(args):
+diff_changedOnly_validate(args):
 
 - If the length of {args} is not 3:
   - Report an error

--- a/spec/14-extensions.md
+++ b/spec/14-extensions.md
@@ -14,7 +14,7 @@ PT type represents an object following [portable text spec](https://github.com/p
 
 This function takes in an object or an array of objects, and returns a PT value.
 
-global::pt(args, scope):
+global_pt(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -29,7 +29,7 @@ global::pt(args, scope):
 - Otherwise:
   - Return {null}.
 
-global::ptValidate(args):
+global_pt_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -38,7 +38,7 @@ global::ptValidate(args):
 
 This function takes in a PT value and returns a string versions of text. PT value which consists of more than one Portable text block has blocks appended with double newline character (`\n\n`) in the string version.
 
-pt::text(args, scope):
+pt_text(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -53,7 +53,7 @@ pt::text(args, scope):
 - Otherwise:
   - Return {null}.
 
-pt::textValidate(args):
+pt_text_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -89,7 +89,7 @@ And, it does not support:
 
 This function is a constructor for geographic value. It takes an object or another geo value, returning a geo value.
 
-global::geo(args, scope):
+global_geo(args, scope):
 
 - Let {baseNode} be the first element of {args}.
 - Let {base} be the result of {Evaluate(baseNode, scope)}.
@@ -102,7 +102,7 @@ global::geo(args, scope):
 - Otherwise:
   - Return {null}.
 
-global::geoValidate(args):
+global_geo_validate(args):
 
 - If the length of {args} is not 1:
   - Report an error.
@@ -111,7 +111,7 @@ global::geoValidate(args):
 
 Returns true if first geo argument completely contains the second one, using a planar (non-spherical) coordinate system. Both geo argument can be any geo value. A geo value is considered contained if all its points are within the boundaries of the first geo value. For `MultiPolygon`, it's sufficient that only one of the polygons contains the first geo value.
 
-geo::contains(args, scope):
+geo_contains(args, scope):
 
 - Let {firstNode} be the first element of {args}.
 - Let {secondNode} be the second element of {args}.
@@ -124,7 +124,7 @@ geo::contains(args, scope):
 - Otherwise:
   - Return {false}.
 
-geo::containsValidate(args):
+geo_contains_validate(args):
 
 - If the length of {args} is not 2:
   - Report an error.
@@ -133,7 +133,7 @@ geo::containsValidate(args):
 
 This function takes two geo values, and returns true if they intersect in a planar (non-spherical) coordinate system. The arguments can be any geo values. A geo value intersects with another if it shares any geometric points with the second value; for example, a line crossing a polygon.
 
-geo::intersects(args, scope):
+geo_intersects(args, scope):
 
 - Let {firstNode} be the first element of {args}.
 - Let {secondNode} be the second element of {args}.
@@ -146,7 +146,7 @@ geo::intersects(args, scope):
 - Otherwise:
   - Return {false}.
 
-geo::intersectsValidate(args):
+geo_intersects_validate(args):
 
 - If the length of {args} is not 2:
   - Report an error.
@@ -155,7 +155,7 @@ geo::intersectsValidate(args):
 
 This functions accepts two geo values, which must be point values, and returns the distance in meters. While exact algorithm is implementation-defined — for example, it may use the [Haversine formula](https://en.wikipedia.org/wiki/Haversine_formula) — it should use as close an approximation to a real Earth distance as possible.
 
-geo::distance(args, scope):
+geo_distance(args, scope):
 
 - Let {firstNode} be the first element of {args}.
 - Let {secondNode} be the second element of {args}.
@@ -170,7 +170,7 @@ geo::distance(args, scope):
 - Otherwise:
   - Return {null}.
 
-geo::distanceValidate(args):
+geo_distance_validate(args):
 
 - If the length of {args} is not 2:
   - Report an error.
@@ -183,7 +183,7 @@ Functions available in the diff extension are grouped under `diff` namespac and 
 
 The `changedAny` function in the `diff` namespace returns a boolean if any of the key paths matched by the selector are changed.
 
-diff::changedAny(args, scope):
+diff_changedAny(args, scope):
 
 - Let {lhs} be the first element of {args}.
 - Let {rhs} be the second element of {args}.
@@ -197,7 +197,7 @@ diff::changedAny(args, scope):
 - Otherwise:
   - Return {false}.
 
-diff::changedAny(args):
+diff_changedAny(args):
 
 - If the length of {args} is not 3:
   - Report an error
@@ -208,7 +208,7 @@ diff::changedAny(args):
 
 The `changedOnly` function in the `diff` namespace returns a boolean if given two nodes only the given key paths matched by the selector are changed.
 
-diff::changedOnly(args, scope):
+diff_changedOnly(args, scope):
 
 - Let {lhs} be the first element of {args}.
 - Let {rhs} be the second element of {args}.
@@ -222,7 +222,7 @@ diff::changedOnly(args, scope):
 - Otherwise:
   - Return {false}.
 
-diff::changedOnly(args):
+diff_changedOnly(args):
 
 - If the length of {args} is not 3:
   - Report an error


### PR DESCRIPTION
- Fix various typos.
- Use `example` code blocks.
- spec-md doesn't support "::" in the middle of an identity which means that these sections weren't handled as "algorithms". This changes it to use _ as delimiter instead which means that they get properly linked, referenced and appears in the index.