### PR TITLE
chore: remove outdated wording from revision 0 and revision 1

### DIFF
--- a/GROQ-1.revision0/index.html
+++ b/GROQ-1.revision0/index.html
@@ -13,10 +13,8 @@
 <header>
 <h1>GROQ</h1>
 <section id="intro">
-<p><em>Current Working Draft</em></p>
 <p>This is the specification for GROQ (<strong>G</strong>raph-<strong>R</strong>elational <strong>O</strong>bject <strong>Q</strong>ueries), a query language and execution engine made at Sanity, Inc, for filtering and projecting JSON documents. The work started in 2015. The development of this open standard started in 2019.</p>
 <p>GROQ is authored by <a href="https://twitter.com/purefiction">Alexander Staubo</a> and <a href="https://twitter.com/svale">Simen Svale Skogsrud</a>. Additional follow up work by <a href="https://twitter.com/erikgrinaker">Erik Grinaker</a>, <a href="https://twitter.com/judofyr">Magnus Holm</a>, <a href="https://github.com/j33ty">Radhe</a>, <a href="https://github.com/israelroldan">Israel Roldan</a>, <a href="https://github.com/sgulseth">Sindre Gulseth</a>, <a href="https://github.com/codebymatt">Matt Craig</a>.</p>
-<p>This specification should be considered <em>work in progress</em> until the first release.</p>
 <section id="sec-Copyright-notice" class="subsec">
 <h6><a href="#sec-Copyright-notice" title="link to this subsection">Copyright notice</a></h6>
 <p>Copyright © 2015&ndash;present, Sanity, Inc.</p>

--- a/GROQ-1.revision1/index.html
+++ b/GROQ-1.revision1/index.html
@@ -13,10 +13,8 @@
 <header>
 <h1>GROQ</h1>
 <section id="intro">
-<p><em>Current Working Draft</em></p>
 <p>This is the specification for GROQ (<strong>G</strong>raph-<strong>R</strong>elational <strong>O</strong>bject <strong>Q</strong>ueries), a query language and execution engine made at Sanity, Inc, for filtering and projecting JSON documents. The work started in 2015. The development of this open standard started in 2019.</p>
 <p>GROQ is authored by <a href="https://twitter.com/purefiction">Alexander Staubo</a> and <a href="https://twitter.com/svale">Simen Svale Skogsrud</a>. Additional follow up work by <a href="https://twitter.com/erikgrinaker">Erik Grinaker</a>, <a href="https://twitter.com/judofyr">Magnus Holm</a>, <a href="https://github.com/j33ty">Radhe</a>, <a href="https://github.com/israelroldan">Israel Roldan</a>, <a href="https://github.com/sgulseth">Sindre Gulseth</a>, <a href="https://github.com/codebymatt">Matt Craig</a>.</p>
-<p>This specification should be considered <em>work in progress</em> until the first release.</p>
 <section id="sec-Copyright-notice" class="subsec">
 <h6><a href="#sec-Copyright-notice" title="link to this subsection">Copyright notice</a></h6>
 <p>Copyright © 2015&ndash;present, Sanity, Inc.</p>

--- a/draft/index.html
+++ b/draft/index.html
@@ -16,7 +16,6 @@
 <p><em>Current Working Draft</em></p>
 <p>This is the specification for GROQ (<strong>G</strong>raph-<strong>R</strong>elational <strong>O</strong>bject <strong>Q</strong>ueries), a query language and execution engine made at Sanity, Inc, for filtering and projecting JSON documents. The work started in 2015. The development of this open standard started in 2019.</p>
 <p>GROQ is authored by <a href="https://twitter.com/purefiction">Alexander Staubo</a> and <a href="https://twitter.com/svale">Simen Svale Skogsrud</a>. Additional follow up work by <a href="https://twitter.com/erikgrinaker">Erik Grinaker</a>, <a href="https://twitter.com/judofyr">Magnus Holm</a>, <a href="https://github.com/j33ty">Radhe</a>, <a href="https://github.com/israelroldan">Israel Roldan</a>, <a href="https://github.com/sgulseth">Sindre Gulseth</a>, <a href="https://github.com/codebymatt">Matt Craig</a>.</p>
-<p>This specification should be considered <em>work in progress</em> until the first release.</p>
 <section id="sec-Copyright-notice" class="subsec">
 <h6><a href="#sec-Copyright-notice" title="link to this subsection">Copyright notice</a></h6>
 <p>Copyright © 2015&ndash;present, Sanity, Inc.</p>


### PR DESCRIPTION
This is a somewhat hacky way of removing this wording, but we need to do it ahead of GROQ-1 release tomorrow.

I didn't remove the `Current working draft` language from the draft spec (since it actually is a working draft).