### PR TITLE
Fix build

### DIFF
--- a/spec/02-syntax.md
+++ b/spec/02-syntax.md
@@ -71,7 +71,7 @@ Comments cannot start inside a string literal.
 
 Identifiers are used to name entities such as parameters, attributes and functions. An identifier is a sequence of one or more letters and digits. The first character in an identifier must be a letter.
 
-Identifier : /[A-Za-z\_][A-Za-z_0-9]\*/
+Identifier : `/[A-Za-z\_][A-Za-z_0-9]\*/`
 
 ## Digits
 


### PR DESCRIPTION
Adds ticks to identifier definition to prevent prettier from formatting it