### PR TITLE
fix(publish): prevent worktree command from changing the HEAD

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install NPM dependencies
       run: npm i
     - name: Add gh-pages worktree
-      run: git fetch origin gh-pages && git worktree add --detach ./gh-pages gh-pages
+      run: git fetch origin gh-pages && git worktree add ./gh-pages gh-pages
     - name: Generate HTML
       run: sh scripts/publish.sh
     - name: Commit and push if it changed

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install NPM dependencies
       run: npm i
     - name: Add gh-pages worktree
-      run: git fetch origin gh-pages && git worktree add ./gh-pages gh-pages
+      run: git fetch origin gh-pages && git worktree add --detach ./gh-pages gh-pages
     - name: Generate HTML
       run: sh scripts/publish.sh
     - name: Commit and push if it changed

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -15,6 +15,9 @@ echo "Publishing to: /draft"
 rm -rf "$PUBLISH_DIR/draft"
 cp -R out/ "$PUBLISH_DIR/draft"
 
+echo "Current head: $(git rev-parse HEAD)"
+echo "Current dir: $(pwd)"
+
 CURRENT_VERSION=$(git tag --points-at HEAD | grep 'GROQ-\d.*')
 
 # If this is a tagged commit, publish to a permalink and index.


### PR DESCRIPTION
When we change the HEAD in step "Add gh-pages worktree" the `publish` script cannot find the correct tag.
This didn't affect the index generation because for that we do `git tag -l --format='%(creatordate:unix) %(refname:lstrip=2)' | sort -r` which lists all tag in the repo, and for publish we do `git tag --points-at HEAD | grep 'GROQ-\d.*'` which only looks at tags pointing at HEAD.