### PR TITLE
docs(binaryPlus): define number + datetime to make this operation commutative

### DIFF
--- a/spec/09-operators.md
+++ b/spec/09-operators.md
@@ -230,7 +230,9 @@ EvaluatePlus(scope):
 - If both {left} and {right} are objects:
   - Return the merged object of {left} and {right}. For duplicate fields the value from {right} takes precedence.
 - If {left} is a datetime and {right} is a number:
-  - Return a new datetime that adds (or subtracts, if negative) {right} as a number of seconds to {left}.
+  - Return a new datetime that adds {right} as a number of seconds to {left}.
+- If {left} is a number and {right} is a datetime:
+  - Return a new datetime that adds {left} as a number of seconds to {right}.
 - Return {null}.
 
 ## Binary minus operator

--- a/spec/GROQ.md
+++ b/spec/GROQ.md
@@ -5,7 +5,7 @@ _Current Working Draft_
 This is the specification for GROQ (**G**raph-**R**elational **O**bject **Q**ueries), a query language and execution engine made at Sanity, Inc, for filtering and projecting JSON documents. The work started in 2015. The development of this open standard started in 2019.
 
 GROQ is authored by [Alexander Staubo](https://twitter.com/purefiction) and [Simen Svale Skogsrud](https://twitter.com/svale).
-Additional follow up work by [Erik Grinaker](https://twitter.com/erikgrinaker), [Magnus Holm](https://twitter.com/judofyr), [Radhe](https://github.com/j33ty), [Israel Roldan](https://github.com/israelroldan), [Sindre Gulseth](https://github.com/sgulseth), [Matt Craig](https://github.com/codebymatt), [Espen Hovlandsdal](https://github.com/rexxars), [Tonina Zhelyazkova](https://github.com/tzhelyazkova).
+Additional follow up work by [Erik Grinaker](https://twitter.com/erikgrinaker), [Magnus Holm](https://twitter.com/judofyr), [Radhe](https://github.com/j33ty), [Israel Roldan](https://github.com/israelroldan), [Sindre Gulseth](https://github.com/sgulseth), [Matt Craig](https://github.com/codebymatt), [Espen Hovlandsdal](https://github.com/rexxars), [Tonina Zhelyazkova](https://github.com/tzhelyazkova), [Kristoffer Brabrand](https://github.com/kbrabrand).
 
 This specification should be considered _work in progress_ until the first release.
 


### PR DESCRIPTION
### TL;DR

Add addition of dateTime to number to the spec to reflect the actual implementation.

### What changed?

The spec currently defines `dateTime + number ⇒ dateTime` and `number + dateTime ⇒ null`, while it has been [implemented as a commutative operation in the query engine](https://github.com/sanity-io/gradient/blob/main/pkg/search/hyperengine/functions/datetimes.go#L29-L50), meaning that the order of the operands is irrelevant.

With this change the spec defines this as a commutative operation, reflecting the actual implementation.